### PR TITLE
OE0-4: added missing perms for 'payer-be' module

### DIFF
--- a/payer/__init__.py
+++ b/payer/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'payer.apps.PayerConfig'

--- a/payer/apps.py
+++ b/payer/apps.py
@@ -1,5 +1,35 @@
 from django.apps import AppConfig
 
+MODULE_NAME = 'payer'
+
+DEFAULT_CFG = {
+    "gql_query_payer_perms": ['121801'],
+    "gql_mutation_payer_add_perms": ['121802'],
+    "gql_mutation_payer_update_perms": ['122103'],
+    "gql_mutation_payer_delete_perms": ['121804'],
+}
+
 
 class PayerConfig(AppConfig):
-    name = 'payer'
+    name = MODULE_NAME
+
+    gql_query_payer_perms = []
+    gql_mutation_payer_add_perms = []
+    gql_mutation_payer_update_perms = []
+    gql_mutation_payer_delete_perms = []
+
+    def _configure_permissions(self, cfg):
+        PayerConfig.gql_query_payer_perms = cfg[
+            "gql_query_payer_perms"]
+        PayerConfig.gql_mutation_payer_add_perms = cfg[
+            "gql_mutation_payer_add_perms"]
+        PayerConfig.gql_mutation_payer_update_perms = cfg[
+            "gql_mutation_payer_update_perms"]
+        PayerConfig.gql_mutation_payer_delete_perms = cfg[
+            "gql_mutation_payer_delete_perms"]
+
+    def ready(self):
+        from core.models import ModuleConfiguration
+        cfg = ModuleConfiguration.get_or_default(MODULE_NAME, DEFAULT_CFG)
+        self._configure_permissions(cfg)
+


### PR DESCRIPTION
part of TICKET https://openimis.atlassian.net/browse/OE0-4

added missing perms for payer module according to https://openimis.atlassian.net/wiki/spaces/OP/pages/1775173658/openIMIS+Authorities